### PR TITLE
fix(fib-heap): fix bug in merge fibonacci heap resolve #26

### DIFF
--- a/algorithms/heap/fibonacci_heap.py
+++ b/algorithms/heap/fibonacci_heap.py
@@ -112,9 +112,15 @@ class FibonacciHeap:
         at the end of this heap's root list and connecting the heads 
         and tails.
         """
-        tail = self.root_list.left
+        if heap2.root_list == None:
+            return
         heap2_tail = heap2.root_list.left
-
+        if self.root_list == None:
+            self.root_list = heap2.root_list
+            self.min_node = heap2.min_node
+            return
+        tail = self.root_list.left
+        
         # the tail of heap 2 is now the end of the list
         self.root_list.left = heap2_tail
         heap2_tail.right = self.root_list

--- a/algorithms/heap/fibonacci_heap.py
+++ b/algorithms/heap/fibonacci_heap.py
@@ -114,11 +114,12 @@ class FibonacciHeap:
         """
         if heap2.root_list == None:
             return
-        heap2_tail = heap2.root_list.left
         if self.root_list == None:
             self.root_list = heap2.root_list
             self.min_node = heap2.min_node
             return
+
+        heap2_tail = heap2.root_list.left
         tail = self.root_list.left
         
         # the tail of heap 2 is now the end of the list


### PR DESCRIPTION
Added check for when the merged heap is empty, the function does
nothing. When the original heap is empty, the funcitno simply
replaces the original heap with the merged heap and switches the
min_nodes. When both heaps are non-empty, the function links the
root lists and updates the min_node.